### PR TITLE
Add comment injections

### DIFF
--- a/languages/asciidoc/injections.scm
+++ b/languages/asciidoc/injections.scm
@@ -11,5 +11,8 @@
 
 ((inline) @injection.content (#set! injection.language "markdown_inline"))
 
-((comment) @injections.content
+((line_comment) @injections.content
+  (#set! injection.language "comment"))
+
+((block_comment) @injections.content
   (#set! injection.language "comment"))


### PR DESCRIPTION
This addition allows the injecting of the `comment` language inside asciidoc to help support this extension [zed-comment](https://github.com/thedadams/zed-comment) extension.