### PR TITLE
Minor improvements

### DIFF
--- a/languages/asciidoc/config.toml
+++ b/languages/asciidoc/config.toml
@@ -1,7 +1,8 @@
 name = "AsciiDoc"
 grammar = "asciidoc"
-path_suffixes = ["asciidoc", "adoc"]
+path_suffixes = ["adoc", "asciidoc", "ad", "asc"]
 line_comments = ["// "]
+block_comment = ["////", "////"]
 brackets = [
   { start = "*", end = "*", close = true, newline = false },
   { start = "`", end = "`", close = true, newline = false },
@@ -12,3 +13,5 @@ brackets = [
   { start = "(", end = ")", close = true, newline = false },
   { start = "<", end = ">", close = true, newline = false },
 ]
+tab_size = 2
+hard_tabs = false


### PR DESCRIPTION
This pull request updates the AsciiDoc language configuration to improve file detection and editor behavior. The key changes focus on expanding file extension support, enhancing comment handling, and specifying formatting preferences.

File extension and comment handling improvements:
* Expanded `path_suffixes` in `languages/asciidoc/config.toml` to include additional file extensions: `.ad` and `.asc`, improving AsciiDoc file detection.
* Added a `block_comment` definition (`////`, `////`) to support block comments in AsciiDoc files.

Editor formatting settings:
* Set `tab_size` to 2 and `hard_tabs` to false, standardizing indentation to 2 spaces instead of tabs for AsciiDoc files.